### PR TITLE
Ignore the `.vercel` directory for output Lambda

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vercel-php",
-  "version": "0.5.0-canary.2",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vercel-php",
-      "version": "0.5.0-canary.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@libphp/amazon-linux-2-v81": "latest"
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@types/glob": "^7.1.2",
         "@types/node": "^14.18.0",
-        "@vercel/build-utils": "^2.15.0",
+        "@vercel/build-utils": "^2.16.0",
         "jest": "^27.0.6",
         "typescript": "^4.6.3"
       }
@@ -1015,9 +1015,9 @@
       "dev": true
     },
     "node_modules/@vercel/build-utils": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-2.15.0.tgz",
-      "integrity": "sha512-0SwM19Mn//v5RuLG5gjuZVOnn1iYqJDMA+N0qm8cK7bTBEWMiTKqF+VmdXkvg6Y6X6rKviAJnOBUUUP6va6Xaw==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-2.16.0.tgz",
+      "integrity": "sha512-KEkt/uhBCMTca4qtRK9F9/M4kV712rkWKYm2p7xo4HVKrF5e+oSEQKF6zDHzUk0R0YOYY1aL3it01r440YsABA==",
       "dev": true
     },
     "node_modules/abab": {
@@ -4822,9 +4822,9 @@
       "dev": true
     },
     "@vercel/build-utils": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-2.15.0.tgz",
-      "integrity": "sha512-0SwM19Mn//v5RuLG5gjuZVOnn1iYqJDMA+N0qm8cK7bTBEWMiTKqF+VmdXkvg6Y6X6rKviAJnOBUUUP6va6Xaw==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-2.16.0.tgz",
+      "integrity": "sha512-KEkt/uhBCMTca4qtRK9F9/M4kV712rkWKYm2p7xo4HVKrF5e+oSEQKF6zDHzUk0R0YOYY1aL3it01r440YsABA==",
       "dev": true
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/glob": "^7.1.2",
     "@types/node": "^14.18.0",
-    "@vercel/build-utils": "^2.15.0",
+    "@vercel/build-utils": "^2.16.0",
     "jest": "^27.0.6",
     "typescript": "^4.6.3"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,12 @@
 import path from 'path';
 import {
-  createLambda,
   rename,
   shouldServe,
-  BuildOptions,
-  PrepareCacheOptions,
   glob,
   download,
-  Lambda
+  Lambda,
+  BuildV3,
+  PrepareCache
 } from '@vercel/build-utils';
 import {
   getPhpFiles,
@@ -26,13 +25,13 @@ const COMPOSER_FILE = process.env.COMPOSER || 'composer.json';
 
 export const version = 3;
 
-export async function build({
+export const build: BuildV3 = async ({
   files,
   entrypoint,
   workPath,
   config = {},
   meta = {},
-}: BuildOptions): Promise<{ output: Lambda }> {
+}) => {
   // Check if now dev mode is used
   if (meta.isDev) {
     console.log(`
@@ -84,10 +83,20 @@ export async function build({
   const harverstedFiles = rename(
     await glob('**', {
       cwd: workPath,
-      ignore:
-        config && config.excludeFiles
-          ? Array.isArray(config.excludeFiles) ? config.excludeFiles : [config.excludeFiles]
-          : ['node_modules/**', 'now.json', '.nowignore', 'vercel.json', '.vercelignore'],
+      ignore: [
+        '.vercel/**',
+        ...(config?.excludeFiles
+          ? Array.isArray(config.excludeFiles)
+            ? config.excludeFiles
+            : [config.excludeFiles]
+          : [
+              'node_modules/**',
+              'now.json',
+              '.nowignore',
+              'vercel.json',
+              '.vercelignore',
+            ]),
+      ],
     }),
     name => path.join('user', name)
   );
@@ -105,7 +114,7 @@ export async function build({
 
   console.log('🐘 Creating lambda');
 
-  const lambda = await createLambda({
+  const lambda = new Lambda({
     files: {
       // Located at /var/task/user
       ...harverstedFiles,
@@ -124,16 +133,16 @@ export async function build({
   return { output: lambda };
 };
 
-export async function prepareCache({ workPath }: PrepareCacheOptions): Promise<RuntimeFiles> {
+export const prepareCache: PrepareCache = async ({ workPath }) => {
   return {
     // Composer
-    ...(await glob('vendor/**', workPath)),
-    ...(await glob('composer.lock', workPath)),
+    ...(await glob("vendor/**", workPath)),
+    ...(await glob("composer.lock", workPath)),
     // NPM
-    ...(await glob('node_modules/**', workPath)),
-    ...(await glob('package-lock.json', workPath)),
-    ...(await glob('yarn.lock', workPath)),
+    ...(await glob("node_modules/**", workPath)),
+    ...(await glob("package-lock.json", workPath)),
+    ...(await glob("yarn.lock", workPath)),
   };
-}
+};
 
 export { shouldServe };

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,12 +136,12 @@ export const build: BuildV3 = async ({
 export const prepareCache: PrepareCache = async ({ workPath }) => {
   return {
     // Composer
-    ...(await glob("vendor/**", workPath)),
-    ...(await glob("composer.lock", workPath)),
+    ...(await glob('vendor/**', workPath)),
+    ...(await glob('composer.lock', workPath)),
     // NPM
-    ...(await glob("node_modules/**", workPath)),
-    ...(await glob("package-lock.json", workPath)),
-    ...(await glob("yarn.lock", workPath)),
+    ...(await glob('node_modules/**', workPath)),
+    ...(await glob('package-lock.json', workPath)),
+    ...(await glob('yarn.lock', workPath)),
   };
 };
 


### PR DESCRIPTION
With the up-coming `vercel build` command, this Builder ends up getting installed into the Project's `.vercel/builders` directory.

The `glob('**', workPath)` code causes this `.vercel` directory to be included in the output Lambda, duplicating the libphp shared libs and causing the function to exceed the 50mb size limit. I added the `.vercel` directory to the "ignore" list for glob so that this doesn't happen ([user report](https://github.com/vercel/community/discussions/577#discussioncomment-2659801)).

I also updated `@vercel/build-utils` and added some types to make things a bit cleaner.